### PR TITLE
Update checkIfAtomDataExists to take strings, create copy of function that outputs boolean w/o error msg.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.m~
+*.asv
 *.DS_Store
 *.csv

--- a/DataManager/RunLibraryObjects/RunDataLibrary.m
+++ b/DataManager/RunLibraryObjects/RunDataLibrary.m
@@ -179,10 +179,10 @@ classdef RunDataLibrary<LibraryCatalog
                 
                 % Get the folder with atomdata.mat in it
                 if (nargin<7)||(isempty(specifiedFolderPath))
-                    checkIfAtomDataExists(runInfo.FilePath)
+                    checkIfAtomDataExists(runInfo.FilePath);
                     folderPath = runInfo.FilePath;
                 else
-                    checkIfAtomDataExists(specifiedFolderPath)
+                    checkIfAtomDataExists(specifiedFolderPath);
                     folderPath = specifiedFolderPath{ii};
                 end
                 

--- a/DataManager/helperFunctions/checkIfAtomDataExists.m
+++ b/DataManager/helperFunctions/checkIfAtomDataExists.m
@@ -1,9 +1,13 @@
-function checkIfAtomDataExists(dataDir)
+function atomdata_exists = checkIfAtomDataExists(dataDir)
     %Check if the folder for the atom data exists
     if ~exist(dataDir,'dir')
+        atomdata_exists = 0;
         error(strcat('The directory (folder).', dataDir ', does not exist'))
     end
     if ~exist(strcat(dataDir, filesep, 'atomdata.mat'),'file')
+        atomdata_exists = 0;
         error(strcat('No atomdata.mat file exists in the directory ', dataDir))
+    else
+        atomdata_exists = 1;
     end
 end

--- a/DataManager/helperFunctions/checkIfAtomDataExists.m
+++ b/DataManager/helperFunctions/checkIfAtomDataExists.m
@@ -1,9 +1,9 @@
 function checkIfAtomDataExists(dataDir)
     %Check if the folder for the atom data exists
     if ~exist(dataDir,'dir')
-        error(['The directory (folder).' dataDir ' does not exist'])
+        error(strcat('The directory (folder).', dataDir ', does not exist'))
     end
-    if ~exist([dataDir filesep 'atomdata.mat'],'file')
-        error(['No atomdata.mat file exists in the directory ',dataDir])
+    if ~exist(strcat(dataDir, filesep, 'atomdata.mat'),'file')
+        error(strcat('No atomdata.mat file exists in the directory ', dataDir))
     end
 end

--- a/DataManager/helperFunctions/checkIfAtomDataExists.m
+++ b/DataManager/helperFunctions/checkIfAtomDataExists.m
@@ -1,13 +1,9 @@
-function atomdata_exists = checkIfAtomDataExists(dataDir)
+function checkIfAtomDataExists(dataDir)
     %Check if the folder for the atom data exists
     if ~exist(dataDir,'dir')
-        atomdata_exists = 0;
-        error(strcat('The directory (folder).', dataDir ', does not exist'))
+        error(strcat("The directory (folder), ", dataDir, ", does not exist"))
     end
     if ~exist(strcat(dataDir, filesep, 'atomdata.mat'),'file')
-        atomdata_exists = 0;
-        error(strcat('No atomdata.mat file exists in the directory ', dataDir))
-    else
-        atomdata_exists = 1;
+        error(strcat("No atomdata.mat file exists in the directory ", dataDir))
     end
 end

--- a/DataManager/helperFunctions/checkIfAtomDataExistsBoolean.m
+++ b/DataManager/helperFunctions/checkIfAtomDataExistsBoolean.m
@@ -1,0 +1,14 @@
+function atomdata_exists = checkIfAtomDataExistsBoolean(dataDir)
+    %Check if the folder for the atom data exists
+    if ~exist(dataDir,'dir')
+        atomdata_exists = 0;
+%         error(strcat("The directory (folder), ", dataDir, ", does not exist"))
+    else
+        if ~exist(strcat(dataDir, filesep, 'atomdata.mat'),'file')
+            atomdata_exists = 0;
+%             error(strcat("No atomdata.mat file exists in the directory ", dataDir))
+        else
+            atomdata_exists = 1;
+        end
+    end
+end

--- a/DataManager/helperFunctions/checkIfAtomDataExistsBoolean.m
+++ b/DataManager/helperFunctions/checkIfAtomDataExistsBoolean.m
@@ -1,4 +1,8 @@
 function atomdata_exists = checkIfAtomDataExistsBoolean(dataDir)
+% CHECKIFATOMDATAEXISTSBOOLEAN checks whether the provided path exists. If
+% so, checks whether atomdata.mat exists in that folder. Returns False if
+% folder or atomdata are not found, True if atomdata is found.
+
     %Check if the folder for the atom data exists
     if ~exist(dataDir,'dir')
         atomdata_exists = 0;


### PR DESCRIPTION
Previous behavior: function fails if fed dataDir as a string (instead of a character vector). Updated to be robust against varying input datatypes for future use.